### PR TITLE
fix: ELF files too large when addresses not contiguous

### DIFF
--- a/axf2elf/Program.cs
+++ b/axf2elf/Program.cs
@@ -245,12 +245,9 @@ namespace axf2elf
 
         static string randomStr(int length = 8)
         {
-            var crypto = RandomNumberGenerator.Create();
-            var bits = length * 6;
-            var byte_size = (bits + 7) / 8;
-            var bytesarray = new byte[byte_size];
-            crypto.GetBytes(bytesarray);
-            return Convert.ToBase64String(bytesarray);
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            return new string(Enumerable.Repeat(chars, length)
+                .Select(s => s[Random.Shared.Next(s.Length)]).ToArray());
         }
 
         static int runExe(string exePath, string args, out string _output)

--- a/axf2elf/Program.cs
+++ b/axf2elf/Program.cs
@@ -74,15 +74,25 @@ namespace axf2elf
 
             int eCode;
             string exe_output;
+            bool is_multiple_rom;
 
             // make bin
             string bin_file_name = Path.GetFileNameWithoutExtension(axf_file_path) + "_" + randomStr() + ".bin";
-            string bin_file_path = Path.GetTempPath() + Path.DirectorySeparatorChar + bin_file_name;
-            eCode = runExe(fromelf_path, $"--bincombined --output \"{bin_file_path}\" \"{axf_file_path}\"", out exe_output);
+            string bin_file_path = Path.GetTempPath() + bin_file_name;
+            eCode = runExe(fromelf_path, $"--bin --output \"{bin_file_path}\" \"{axf_file_path}\"", out exe_output);
             if (eCode != CODE_DONE)
             {
                 log(exe_output);
                 return CODE_ERR;
+            }
+
+            if (Directory.Exists(bin_file_path))
+            {
+                is_multiple_rom = true;
+            }
+            else
+            {
+                is_multiple_rom = false;
             }
 
             // get axf information
@@ -177,39 +187,28 @@ namespace axf2elf
 
             // === generate command line ===
 
-            section_info entry_section = null;
-            List<string> rm_sec_list = new List<string>();
+            List<string> rom_section_list = new List<string>();
 
             foreach (section_info sec_info in section_list)
             {
-                if (sec_info.address == entry_header_addr)
+                if (!Array.Exists(sec_info.flags, delegate (string flag) { return flag == "SHF_WRITE"; }))
                 {
-                    if (entry_section != null)
-                    {
-                        error("error !, duplicated entry section: " + entry_section.name + " and " + sec_info.name);
-                        return CODE_ERR;
-                    }
-
-                    entry_section = sec_info;
-                }
-
-                else if (!Array.Exists(sec_info.flags, delegate (string flag) { return flag == "SHF_WRITE"; }))
-                {
-                    rm_sec_list.Add(sec_info.name);
+                    rom_section_list.Add(sec_info.name);
                 }
             }
 
-            if (entry_section == null)
+            if (rom_section_list.Count <= 0)
             {
-                error("not found entry section !");
+                error("not found ROM section !");
                 return CODE_ERR;
             }
 
-            string command_params = "--update-section " + entry_section.name + "=\"" + bin_file_path + "\"";
-
-            foreach (string sec_name in rm_sec_list)
+            string command_params = "";
+            string rom_path;
+            foreach (string sec_name in rom_section_list)
             {
-                command_params += " --remove-section " + sec_name;
+                rom_path = is_multiple_rom ? (bin_file_path + Path.DirectorySeparatorChar + sec_name) : bin_file_path;
+                command_params += "--update-section " + sec_name + "=\"" + rom_path + "\" ";
             }
 
             string command_line = command_params
@@ -227,11 +226,18 @@ namespace axf2elf
             // === clean ===
             try
             {
-                File.Delete(bin_file_path);
+                if (is_multiple_rom)
+                {
+                    Directory.Delete(bin_file_path, true);
+                }
+                else
+                {
+                    File.Delete(bin_file_path);
+                }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                log($"fail to delete temp file: {bin_file_path}");
+                log($"fail to delete temp file or folder: {bin_file_path}, Error message: {ex.Message}");
             }
 
             return eCode;


### PR DESCRIPTION
当定义多个加载域后，地址不连续，会导致ELF中填充大量数据，ELF文件巨大：
<img width="575" height="328" alt="big_elf" src="https://github.com/user-attachments/assets/030bc8a9-1856-470c-be71-9a29d66e034b" />

原因是将其他加载域的section全部放在ENTRY section导致的，因此只要把对应加载域的section用objcopy到对应的section即可。

测试文件axf的elf信息如下（为了避免空间爆掉，测试时EXT_FLASH起始地址为0x08900000）：
```
fromelf -r xxx.axf
========================================================================

** ELF Header Information

    File Name: xxx.axf
...
========================================================================
** Program header #0 (PT_LOAD) [PF_X + PF_W + PF_R + PF_ARM_ENTRY]
    Size : 220336 bytes (146592 bytes in file)
    Virtual address: 0x08000000 (Alignment 16)
====================================
** Program header #1 (PT_LOAD) [PF_R]
    Size : 308028 bytes
    Virtual address: 0x08900000 (Alignment 4)
========================================================================
** Section #1 'ER_IROM1' (SHT_PROGBITS) [SHF_ALLOC + SHF_EXECINSTR]
    Size   : 146540 bytes (alignment 16)
    Address: 0x08000000

** Section #2 'RW_IRAM1' (SHT_PROGBITS) [SHF_ALLOC + SHF_WRITE]
    Size   : 48 bytes (alignment 8)
    Address: 0x20000000

** Section #3 'RW_IRAM1' (SHT_NOBITS) [SHF_ALLOC + SHF_WRITE]
    Size   : 73744 bytes (alignment 8)
    Address: 0x20000030

** Section #4 'EXT_FLASH' (SHT_PROGBITS) [SHF_ALLOC]
    Size   : 308028 bytes (alignment 4)
    Address: 0x08900000
...
```

修改前的elf信息如下：
```
fromelf -r xxx.elf
"xxx.elf": Warning: Q0479W: In ELF file: Section/segment mapping in SHT_NOTE section #10 contains 4 entries, but there are 3 SHF_ALLOC sections
========================================================================
** ELF Header Information
    File Name: xxx.elf
...
========================================================================
** Program header #0 (PT_LOAD) [PF_X + PF_W + PF_R + PF_ARM_ENTRY]
    Size : 9745212 bytes
    Virtual address: 0x08000000 (Alignment 16)
====================================
** Program header #1 (PT_LOAD) [PF_R]
    Size : 0 bytes
    Virtual address: 0x08900000 (Alignment 4)
========================================================================
** Section #1 'ER_IROM1' (SHT_PROGBITS) [SHF_ALLOC + SHF_EXECINSTR]
    Size   : 9745212 bytes (alignment 16)
    Address: 0x08000000

** Section #2 'RW_IRAM1' (SHT_PROGBITS) [SHF_ALLOC + SHF_WRITE]
    Size   : 48 bytes (alignment 8)
    Address: 0x20000000

** Section #3 'RW_IRAM1' (SHT_NOBITS) [SHF_ALLOC + SHF_WRITE]
    Size   : 73744 bytes (alignment 8)
    Address: 0x20000030
...
```

修改前`EXT_FLASH`的大小为0字节，根据axf的信息，`0x08900000(EXT_FLASH Start Addr) - 0x08000000 (ER_IROM1 Start Addr) + 330028(EXT_FLASH Size) = 9745212`，是可以对的上`ER_IROM1`的大小的，这证明`EXT_FLASH`全部被塞到了`ER_IROM1`中。

如果是STM32 QSPI的地址(0x90000000)，那么文件体积会达到2G多！而且其中绝大多数都是无用的空数据。

修改后的elf信息如下：
```
fromelf -r xxx.elf
========================================================================
** ELF Header Information
    File Name: xxx.elf
...
========================================================================
** Program header #0 (PT_LOAD) [PF_X + PF_W + PF_R + PF_ARM_ENTRY]
    Size : 146608 bytes
    Virtual address: 0x08000000 (Alignment 16)
====================================
** Program header #1 (PT_LOAD) [PF_R]
    Size : 330028 bytes
    Virtual address: 0x08900000 (Alignment 4)
========================================================================
** Section #1 'ER_IROM1' (SHT_PROGBITS) [SHF_ALLOC + SHF_EXECINSTR]
    Size   : 146608 bytes (alignment 16)
    Address: 0x08000000

** Section #2 'RW_IRAM1' (SHT_PROGBITS) [SHF_ALLOC + SHF_WRITE]
    Size   : 48 bytes (alignment 8)
    Address: 0x20000000

** Section #3 'RW_IRAM1' (SHT_NOBITS) [SHF_ALLOC + SHF_WRITE]
    Size   : 73744 bytes (alignment 8)
    Address: 0x20000030

** Section #4 'EXT_FLASH' (SHT_PROGBITS) [SHF_ALLOC]
    Size   : 330028 bytes (alignment 4)
    Address: 0x08900000
...
```

fromelf如果不合并bin，会将bin按照section名称在输出文件下建立bin文件，按照文件名copy就可以了。

调试前，gdb server会下载其他Flash：
<img width="864" height="716" alt="debug" src="https://github.com/user-attachments/assets/c4711318-e74d-4314-8704-37a1a1c9ac14" />

且调试时RW段不会变成0xFF：
<img width="1312" height="449" alt="debug2" src="https://github.com/user-attachments/assets/05aee585-6a12-480d-a8a1-95c7d3e7338a" />
